### PR TITLE
access allowed to OPTIONS requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,9 +43,13 @@ app.use((req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader(
     'Access-Control-Allow-Methods',
-    'GET, PUT, POST, PATCH, DELETE, OPTION'
+    'GET, PUT, POST, PATCH, DELETE, OPTIONS'
   );
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.sendStatus(200)
+  }
   next();
 });
 


### PR DESCRIPTION
OPTIONS method sent by the browser are not allowed by default when using the graphql package; because of that,  a 200 status code is send as response to the browser so it will send the request that is trying to access the server